### PR TITLE
Feat: Add additional custom fields to the SAML response

### DIFF
--- a/src/idp/mod.rs
+++ b/src/idp/mod.rs
@@ -155,6 +155,8 @@ impl IdentityProvider {
             &optional_arguments.not_before,
             &optional_arguments.not_on_or_after,
             &optional_arguments.digest_algorithm,
+            &optional_arguments.destination.as_deref(),
+            &optional_arguments.recipient.as_deref(),
         );
 
         let response_xml_unsigned = response.to_string()?;

--- a/src/idp/mod.rs
+++ b/src/idp/mod.rs
@@ -8,6 +8,7 @@ pub mod verified_request;
 #[cfg(test)]
 mod tests;
 
+use chrono::{DateTime, Utc};
 use openssl::bn::{BigNum, MsbOption};
 use openssl::ec::{EcGroup, EcKey};
 use openssl::nid::Nid;
@@ -146,6 +147,8 @@ impl IdentityProvider {
         issuer: &str,
         in_response_to_id: &str,
         attributes: &[ResponseAttribute],
+        not_before: &Option<DateTime<Utc>>,
+        not_on_or_after: &Option<DateTime<Utc>>,
     ) -> Result<Response, Box<dyn std::error::Error>> {
         let response = build_response_template(
             idp_x509_cert_der,
@@ -156,6 +159,8 @@ impl IdentityProvider {
             in_response_to_id,
             attributes,
             &self.name_id_format,
+            not_before,
+            not_on_or_after,
         );
 
         let response_xml_unsigned = response.to_string()?;

--- a/src/idp/mod.rs
+++ b/src/idp/mod.rs
@@ -21,11 +21,13 @@ use crate::crypto::{self};
 use crate::idp::response_builder::{build_response_template, ResponseAttribute};
 use crate::metadata::NameIdFormat;
 use crate::schema::Response;
+use crate::signature::DigestAlgorithm;
 use crate::traits::ToXml;
 
 pub struct IdentityProvider {
     private_key: pkey::PKey<Private>,
     name_id_format: NameIdFormat,
+    digest_algorithm: DigestAlgorithm,
 }
 
 pub enum Rsa {
@@ -80,6 +82,7 @@ impl IdentityProvider {
         Ok(IdentityProvider {
             private_key,
             name_id_format: NameIdFormat::default(),
+            digest_algorithm: DigestAlgorithm::default(),
         })
     }
 
@@ -90,6 +93,7 @@ impl IdentityProvider {
         Ok(IdentityProvider {
             private_key,
             name_id_format: NameIdFormat::default(),
+            digest_algorithm: DigestAlgorithm::default(),
         })
     }
 
@@ -161,6 +165,7 @@ impl IdentityProvider {
             &self.name_id_format,
             not_before,
             not_on_or_after,
+            &self.digest_algorithm,
         );
 
         let response_xml_unsigned = response.to_string()?;
@@ -182,6 +187,20 @@ impl IdentityProvider {
     /// ```
     pub fn with_name_id_format(mut self, name_id_format: NameIdFormat) -> Self {
         self.name_id_format = name_id_format;
+
+        self
+    }
+
+    /// Change the algorithm used to create the assertion digest.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let idp = IdentityProvider::from_rsa_private_key_der(&der_bytes)?
+    ///     .with_digest_algorithm(DigestAlgorithm::Sha256);
+    /// ```
+    pub fn with_digest_algorithm(mut self, digest_algorithm: DigestAlgorithm) -> Self {
+        self.digest_algorithm = digest_algorithm;
 
         self
     }

--- a/src/idp/response_builder.rs
+++ b/src/idp/response_builder.rs
@@ -5,7 +5,7 @@ use crate::schema::{
     AuthnStatement, Conditions, Issuer, Response, Status, StatusCode, Subject, SubjectConfirmation,
     SubjectConfirmationData, SubjectNameID,
 };
-use crate::signature::Signature;
+use crate::signature::{DigestAlgorithm, Signature};
 use chrono::{DateTime, Utc};
 
 use super::sp_extractor::RequiredAttribute;
@@ -119,6 +119,7 @@ fn build_response(
     name_id_format: &NameIdFormat,
     not_before: &Option<DateTime<Utc>>,
     not_on_or_after: &Option<DateTime<Utc>>,
+    digest_algorithm: &DigestAlgorithm,
 ) -> Response {
     let issuer = Issuer {
         value: Some(issuer.to_string()),
@@ -135,7 +136,11 @@ fn build_response(
         destination: Some(destination.to_string()),
         consent: None,
         issuer: Some(issuer.clone()),
-        signature: Some(Signature::template(&response_id, x509_cert)),
+        signature: Some(Signature::template(
+            &response_id,
+            x509_cert,
+            digest_algorithm,
+        )),
         status: Some(Status {
             status_code: StatusCode {
                 value: Some("urn:oasis:names:tc:SAML:2.0:status:Success".to_string()),
@@ -169,6 +174,7 @@ pub fn build_response_template(
     name_id_format: &NameIdFormat,
     not_before: &Option<DateTime<Utc>>,
     not_on_or_after: &Option<DateTime<Utc>>,
+    digest_algorithm: &DigestAlgorithm,
 ) -> Response {
     build_response(
         name_id,
@@ -181,5 +187,6 @@ pub fn build_response_template(
         name_id_format,
         not_before,
         not_on_or_after,
+        digest_algorithm,
     )
 }

--- a/src/idp/response_builder.rs
+++ b/src/idp/response_builder.rs
@@ -120,6 +120,7 @@ fn build_response(
     not_before: &Option<DateTime<Utc>>,
     not_on_or_after: &Option<DateTime<Utc>>,
     digest_algorithm: &DigestAlgorithm,
+    recipient: &Option<&str>,
 ) -> Response {
     let issuer = Issuer {
         value: Some(issuer.to_string()),
@@ -127,6 +128,10 @@ fn build_response(
     };
 
     let response_id = crypto::gen_saml_response_id();
+
+    // If an optional recipient has been provided, use that. Else use the
+    // destination which is the standard.
+    let recipient = recipient.unwrap_or(destination);
 
     Response {
         id: response_id.clone(),
@@ -153,7 +158,7 @@ fn build_response(
             name_id,
             request_id,
             issuer,
-            destination,
+            recipient,
             audience,
             attributes,
             name_id_format,
@@ -175,18 +180,25 @@ pub fn build_response_template(
     not_before: &Option<DateTime<Utc>>,
     not_on_or_after: &Option<DateTime<Utc>>,
     digest_algorithm: &DigestAlgorithm,
+    destination: &Option<&str>,
+    recipient: &Option<&str>,
 ) -> Response {
+    // If an optional destination has been provided, use that. Else use the ACS
+    // URL which is the standard.
+    let destination = destination.unwrap_or(acs_url);
+
     build_response(
         name_id,
         issuer,
         request_id,
         attributes,
-        acs_url,
+        destination,
         audience,
         cert_der,
         name_id_format,
         not_before,
         not_on_or_after,
         digest_algorithm,
+        recipient,
     )
 }

--- a/src/idp/tests.rs
+++ b/src/idp/tests.rs
@@ -97,8 +97,7 @@ fn test_signed_response() {
             "https://idp.example.com",
             verified.id.as_str(),
             &attrs,
-            &None,
-            &None,
+            &Default::default(),
         )
         .expect("failed to created and sign response");
 
@@ -158,8 +157,7 @@ fn test_signed_response_fingerprint() {
             "https://idp.example.com",
             "",
             &[],
-            &None,
-            &None,
+            &Default::default(),
         )
         .expect("failed to created and sign response");
     let base64_cert = response
@@ -357,8 +355,7 @@ fn test_email_name_id_format() {
     let idp = IdentityProvider::from_rsa_private_key_der(include_bytes!(
         "../../test_vectors/idp_private_key.der"
     ))
-    .expect("failed to create idp")
-    .with_name_id_format(NameIdFormat::EmailAddressNameIDFormat);
+    .expect("failed to create idp");
 
     let params = CertificateParams {
         common_name: "https://idp.example.com",
@@ -374,6 +371,9 @@ fn test_email_name_id_format() {
         .try_verify_self_signed()
         .expect("failed to verify self signed signature");
 
+    let optional_arguments =
+        OptionalSigningArgs::default().with_name_id_format(NameIdFormat::EmailAddressNameIDFormat);
+
     // Act
     let out_response = idp
         .sign_authn_response(
@@ -384,8 +384,7 @@ fn test_email_name_id_format() {
             "https://idp.example.com",
             verified.id.as_str(),
             &[],
-            &None,
-            &None,
+            &optional_arguments,
         )
         .expect("failed to created and sign response");
 
@@ -429,6 +428,10 @@ fn test_not_before_and_after_conditions() {
     let not_before = Utc::now();
     let not_on_or_after = Utc::now() + Duration::hours(1);
 
+    let optional_arguments = OptionalSigningArgs::default()
+        .with_not_before(not_before)
+        .with_not_on_or_after(not_on_or_after);
+
     // Act
     let out_response = idp
         .sign_authn_response(
@@ -439,8 +442,7 @@ fn test_not_before_and_after_conditions() {
             "https://idp.example.com",
             verified.id.as_str(),
             &[],
-            &Some(not_before),
-            &Some(not_on_or_after),
+            &optional_arguments,
         )
         .expect("failed to created and sign response");
 
@@ -460,13 +462,12 @@ fn test_not_before_and_after_conditions() {
 }
 
 #[test]
-fn test_altering_assertion_digest() {
+fn test_altering_assertion_digest_to_sha256() {
     // Arrange
     let idp = IdentityProvider::from_rsa_private_key_der(include_bytes!(
         "../../test_vectors/idp_private_key.der"
     ))
-    .expect("failed to create idp")
-    .with_digest_algorithm(DigestAlgorithm::Sha256);
+    .expect("failed to create idp");
 
     let params = CertificateParams {
         common_name: "https://idp.example.com",
@@ -482,6 +483,9 @@ fn test_altering_assertion_digest() {
         .try_verify_self_signed()
         .expect("failed to verify self signed signature");
 
+    let optional_arguments =
+        OptionalSigningArgs::default().with_digest_algorithm(DigestAlgorithm::Sha256);
+
     // Act
     let out_response = idp
         .sign_authn_response(
@@ -492,8 +496,7 @@ fn test_altering_assertion_digest() {
             "https://idp.example.com",
             verified.id.as_str(),
             &[],
-            &None,
-            &None,
+            &optional_arguments,
         )
         .expect("failed to created and sign response");
 

--- a/src/idp/tests.rs
+++ b/src/idp/tests.rs
@@ -513,3 +513,140 @@ fn test_altering_assertion_digest_to_sha256() {
     verify_signed_xml(out_xml.as_bytes(), idp_cert.as_slice(), Some("ID"))
         .expect("verification failed");
 }
+
+#[test]
+fn test_that_providing_destination_will_use_that_instead_of_acs() {
+    // Arrange
+    let idp = IdentityProvider::from_rsa_private_key_der(include_bytes!(
+        "../../test_vectors/idp_private_key.der"
+    ))
+    .expect("failed to create idp");
+
+    let params = CertificateParams {
+        common_name: "https://idp.example.com",
+        issuer_name: "https://idp.example.com",
+        days_until_expiration: 3650,
+    };
+
+    let idp_cert = idp.create_certificate(&params).expect("idp cert error");
+
+    let authn_request_xml = include_str!("../../test_vectors/authn_request.xml");
+    let unverified = UnverifiedAuthnRequest::from_xml(authn_request_xml).expect("failed to parse");
+    let verified = unverified
+        .try_verify_self_signed()
+        .expect("failed to verify self signed signature");
+
+    let acs = "https://sp.example.com/acs";
+    let destination = "custom-destination";
+
+    // Act
+    let out_response_no_destination = idp
+        .sign_authn_response(
+            idp_cert.as_slice(),
+            "testuser@example.com",
+            "https://sp.example.com/audience",
+            acs,
+            "https://idp.example.com",
+            verified.id.as_str(),
+            &[],
+            &OptionalSigningArgs::default(),
+        )
+        .expect("failed to created and sign response");
+
+    let out_response_with_destination = idp
+        .sign_authn_response(
+            idp_cert.as_slice(),
+            "testuser@example.com",
+            "https://sp.example.com/audience",
+            acs,
+            "https://idp.example.com",
+            verified.id.as_str(),
+            &[],
+            &OptionalSigningArgs::default().with_destination(destination.to_owned()),
+        )
+        .expect("failed to created and sign response");
+
+    // Assert
+    let out_xml_no_destination = out_response_no_destination
+        .to_string()
+        .expect("failed to serialize response xml");
+    let out_xml_with_destination = out_response_with_destination
+        .to_string()
+        .expect("failed to serialize response xml");
+
+    assert!(out_xml_no_destination.contains(&format!("Destination=\"{acs}\"")));
+    assert!(!out_xml_no_destination.contains(&format!("Destination=\"{destination}\"")));
+
+    assert!(out_xml_with_destination.contains(&format!("Destination=\"{destination}\"")));
+    assert!(!out_xml_with_destination.contains(&format!("Destination=\"{acs}\"")));
+}
+
+#[test]
+fn test_that_providing_recipient_will_use_that_instead_of_destination() {
+    // Arrange
+    let idp = IdentityProvider::from_rsa_private_key_der(include_bytes!(
+        "../../test_vectors/idp_private_key.der"
+    ))
+    .expect("failed to create idp");
+
+    let params = CertificateParams {
+        common_name: "https://idp.example.com",
+        issuer_name: "https://idp.example.com",
+        days_until_expiration: 3650,
+    };
+
+    let idp_cert = idp.create_certificate(&params).expect("idp cert error");
+
+    let authn_request_xml = include_str!("../../test_vectors/authn_request.xml");
+    let unverified = UnverifiedAuthnRequest::from_xml(authn_request_xml).expect("failed to parse");
+    let verified = unverified
+        .try_verify_self_signed()
+        .expect("failed to verify self signed signature");
+
+    let acs = "https://sp.example.com/acs";
+    let destination = "custom-destination";
+    let recipient = "custom-recipient";
+
+    // Act
+    let out_response_no_recipient = idp
+        .sign_authn_response(
+            idp_cert.as_slice(),
+            "testuser@example.com",
+            "https://sp.example.com/audience",
+            acs,
+            "https://idp.example.com",
+            verified.id.as_str(),
+            &[],
+            &OptionalSigningArgs::default().with_destination(destination.to_owned()),
+        )
+        .expect("failed to created and sign response");
+
+    let out_response_with_recipient = idp
+        .sign_authn_response(
+            idp_cert.as_slice(),
+            "testuser@example.com",
+            "https://sp.example.com/audience",
+            acs,
+            "https://idp.example.com",
+            verified.id.as_str(),
+            &[],
+            &OptionalSigningArgs::default()
+                .with_destination(destination.to_owned())
+                .with_recipient(recipient.to_owned()),
+        )
+        .expect("failed to created and sign response");
+
+    // Assert
+    let out_xml_no_recipient = out_response_no_recipient
+        .to_string()
+        .expect("failed to serialize response xml");
+    let out_xml_with_recipient = out_response_with_recipient
+        .to_string()
+        .expect("failed to serialize response xml");
+
+    assert!(out_xml_no_recipient.contains(&format!("Recipient=\"{destination}\"")));
+    assert!(!out_xml_no_recipient.contains(&format!("Recipient=\"{recipient}\"")));
+
+    assert!(out_xml_with_recipient.contains(&format!("Recipient=\"{recipient}\"")));
+    assert!(!out_xml_with_recipient.contains(&format!("Recipient=\"{destination}\"")));
+}

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -22,7 +22,11 @@ pub struct Signature {
 }
 
 impl Signature {
-    pub fn template(ref_id: &str, x509_cert_der: &[u8]) -> Self {
+    pub fn template(
+        ref_id: &str,
+        x509_cert_der: &[u8],
+        digest_algorithm: &DigestAlgorithm,
+    ) -> Self {
         Signature {
             id: None,
             signed_info: SignedInfo {
@@ -49,7 +53,7 @@ impl Signature {
                         ],
                     }),
                     digest_method: DigestMethod {
-                        algorithm: DigestAlgorithm::Sha1,
+                        algorithm: digest_algorithm.clone(),
                     },
                     digest_value: Some(DigestValue {
                         base64_content: Some("".to_string()),
@@ -448,8 +452,9 @@ impl TryFrom<&DigestMethod> for Event<'_> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Default)]
 pub enum DigestAlgorithm {
+    #[default]
     #[serde(rename = "http://www.w3.org/2000/09/xmldsig#sha1")]
     Sha1,
     #[serde(rename = "http://www.w3.org/2001/04/xmlenc#sha256")]


### PR DESCRIPTION
Adds:

- `NotBefore` and `NotOnOrBefore` fields
- Customizable `Recipient` and `Destination`
- Selectable digest algorithm