### PR TITLE
feat(response): Allow ResponseAttributes to have multiple values

### DIFF
--- a/src/idp/response_builder.rs
+++ b/src/idp/response_builder.rs
@@ -44,7 +44,7 @@ fn build_authn_statement(class: &str) -> AuthnStatement {
 #[derive(Debug, Clone)]
 pub struct ResponseAttribute {
     pub required_attribute: RequiredAttribute,
-    pub value: String,
+    pub values: Vec<String>,
 }
 
 fn build_attributes(formats_names_values: &[ResponseAttribute]) -> Vec<Attribute> {
@@ -54,10 +54,14 @@ fn build_attributes(formats_names_values: &[ResponseAttribute]) -> Vec<Attribute
             friendly_name: None,
             name: Some(attr.required_attribute.name.clone()),
             name_format: attr.required_attribute.format.clone(),
-            values: vec![AttributeValue {
-                attribute_type: Some("xs:string".to_string()),
-                value: Some(attr.value.to_string()),
-            }],
+            values: attr
+                .values
+                .iter()
+                .map(|value| AttributeValue {
+                    attribute_type: Some("xs:string".to_string()),
+                    value: Some(value.to_owned()),
+                })
+                .collect(),
         })
         .collect()
 }

--- a/src/idp/tests.rs
+++ b/src/idp/tests.rs
@@ -83,7 +83,7 @@ fn test_signed_response() {
                 name: attr.1.to_string(),
                 format: Some(attr.0.to_string()),
             },
-            value: attr.2.to_string(),
+            values: vec![attr.2.to_string()],
         })
         .collect::<Vec<ResponseAttribute>>();
 


### PR DESCRIPTION
`samael`'s response attributes aren't able to handle more than one attribute value per attribute. This is something that is in the SAML spec an will be required for displaying groups and other list type attributes.

This PR updates `samael`'s `ResponseAttribute` type so that it is able to handle multiple attribute values per attribute.