### PR TITLE
SAML: Make NameID format Configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +293,12 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "iana-time-zone"
@@ -458,6 +470,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +489,12 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -747,6 +777,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "samael"
 version = "0.0.19"
 dependencies = [
@@ -768,27 +804,51 @@ dependencies = [
  "serde",
  "thiserror",
  "url",
+ "utoipa",
  "uuid",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -895,6 +955,30 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ flate2 = "^1.0.0"
 rand = "^0.9.0"
 derive_builder = "^0.20.0"
 libxml = { version = "=0.3.3", optional = true }
+utoipa = { version = "5.3.1", features = ["axum_extras"] }
 uuid = { version = "^1.3.0", features = ["v4"] }
 data-encoding = "2.9.0"
 libc = { version = "^0.2.66", optional = true }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -713,7 +713,7 @@ pub(crate) fn decrypt_aead(
 #[cfg(test)]
 mod test {
     use super::UrlVerifier;
-    use crate::service_provider::ServiceProvider;
+    use crate::{metadata::HTTP_REDIRECT_BINDING, service_provider::ServiceProvider};
     use chrono::{DateTime, Utc};
 
     #[test]
@@ -740,7 +740,7 @@ mod test {
         };
 
         let authn_request = sp
-            .make_authentication_request("http://dummy.fake/saml")
+            .make_authentication_request("http://dummy.fake/saml", HTTP_REDIRECT_BINDING)
             .unwrap();
 
         let private_key = openssl::rsa::Rsa::private_key_from_der(private_key).unwrap();
@@ -792,7 +792,7 @@ mod test {
         };
 
         let authn_request = sp
-            .make_authentication_request("http://dummy.fake/saml")
+            .make_authentication_request("http://dummy.fake/saml", HTTP_REDIRECT_BINDING)
             .unwrap();
 
         let private_key = openssl::ec::EcKey::private_key_from_pem(private_key).unwrap();

--- a/src/idp/verified_request.rs
+++ b/src/idp/verified_request.rs
@@ -11,7 +11,7 @@ pub struct UnverifiedAuthnRequest<'a> {
 }
 
 impl<'a> UnverifiedAuthnRequest<'a> {
-    pub fn from_xml(xml: &str) -> Result<UnverifiedAuthnRequest, Error> {
+    pub fn from_xml(xml: &str) -> Result<UnverifiedAuthnRequest<'_>, Error> {
         Ok(UnverifiedAuthnRequest {
             request: xml.parse()?,
             xml,

--- a/src/metadata/endpoint.rs
+++ b/src/metadata/endpoint.rs
@@ -14,7 +14,7 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
-    pub fn to_xml(&self, element_name: &str) -> Result<Event, Box<dyn std::error::Error>> {
+    pub fn to_xml(&self, element_name: &str) -> Result<Event<'_>, Box<dyn std::error::Error>> {
         let mut write_buf = Vec::new();
         let mut writer = Writer::new(Cursor::new(&mut write_buf));
         let mut root = BytesStart::new(element_name);
@@ -46,7 +46,7 @@ pub struct IndexedEndpoint {
 }
 
 impl IndexedEndpoint {
-    pub fn to_xml(&self, element_name: &str) -> Result<Event, Box<dyn std::error::Error>> {
+    pub fn to_xml(&self, element_name: &str) -> Result<Event<'_>, Box<dyn std::error::Error>> {
         let mut write_buf = Vec::new();
         let mut writer = Writer::new(Cursor::new(&mut write_buf));
         let mut root = BytesStart::new(element_name);

--- a/src/metadata/entity_descriptor.rs
+++ b/src/metadata/entity_descriptor.rs
@@ -30,7 +30,7 @@ pub enum EntityDescriptorType {
 }
 
 impl EntityDescriptorType {
-    pub fn iter(&self) -> EntityDescriptorIterator {
+    pub fn iter(&self) -> EntityDescriptorIterator<'_> {
         EntityDescriptorIterator::new(self)
     }
 }

--- a/src/metadata/localized.rs
+++ b/src/metadata/localized.rs
@@ -13,7 +13,7 @@ pub struct LocalizedName {
 }
 
 impl LocalizedName {
-    pub fn to_xml(&self, element_name: &str) -> Result<Event, Box<dyn std::error::Error>> {
+    pub fn to_xml(&self, element_name: &str) -> Result<Event<'_>, Box<dyn std::error::Error>> {
         let mut write_buf = Vec::new();
         let mut writer = Writer::new(Cursor::new(&mut write_buf));
         let mut root = BytesStart::new(element_name);
@@ -39,7 +39,7 @@ pub struct LocalizedUri {
 }
 
 impl LocalizedUri {
-    pub fn to_xml(&self, element_name: &str) -> Result<Event, Box<dyn std::error::Error>> {
+    pub fn to_xml(&self, element_name: &str) -> Result<Event<'_>, Box<dyn std::error::Error>> {
         let mut write_buf = Vec::new();
         let mut writer = Writer::new(Cursor::new(&mut write_buf));
         let mut root = BytesStart::new(element_name);

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -26,6 +26,7 @@ pub mod de {
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::Writer;
 use std::io::Cursor;
+use utoipa::ToSchema;
 
 use serde::Deserialize;
 
@@ -40,7 +41,7 @@ pub const HTTP_POST_BINDING: &str = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-P
 // HTTP_REDIRECT_BINDING is the official URN for the HTTP-Redirect binding (transport)
 pub const HTTP_REDIRECT_BINDING: &str = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
 
-#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Default)]
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Default, ToSchema)]
 pub enum NameIdFormat {
     #[default]
     UnspecifiedNameIDFormat,

--- a/src/service_provider/mod.rs
+++ b/src/service_provider/mod.rs
@@ -145,7 +145,7 @@ impl From<crypto::Error> for Error {
     }
 }
 
-#[derive(Builder, Clone)]
+#[derive(Builder, Debug, Clone)]
 #[builder(default, setter(into))]
 pub struct ServiceProvider {
     pub entity_id: Option<String>,
@@ -521,6 +521,7 @@ impl ServiceProvider {
     pub fn make_authentication_request(
         &self,
         idp_url: &str,
+        binding: &str,
     ) -> Result<AuthnRequest, Box<dyn std::error::Error>> {
         let entity_id = if let Some(entity_id) = self.entity_id.clone() {
             Some(entity_id)
@@ -531,7 +532,7 @@ impl ServiceProvider {
         Ok(AuthnRequest {
             assertion_consumer_service_url: self.acs_url.clone(),
             destination: Some(idp_url.to_string()),
-            protocol_binding: Some(HTTP_POST_BINDING.to_string()),
+            protocol_binding: Some(binding.to_string()),
             id: format!("id-{}", rand::random::<u32>()),
             issue_instant: Utc::now(),
             version: "2.0".to_string(),


### PR DESCRIPTION
Just small changes.
1. Adding some derive macros so that the derive's work up the calling chain.
2. Lint fixes around lifetimes (Added `<'_>` to some return types as per clippy.)
3. Added Utopia so we have `ToSchema`