### PR TITLE
fix: remove NotBefore from SubjectConfirmationData

### DIFF
--- a/src/idp/response_builder.rs
+++ b/src/idp/response_builder.rs
@@ -103,7 +103,7 @@ fn build_assertion_signed(
                 method: Some("urn:oasis:names:tc:SAML:2.0:cm:bearer".to_string()),
                 name_id: None,
                 subject_confirmation_data: Some(SubjectConfirmationData {
-                    not_before: *not_before,
+                    not_before: None,
                     not_on_or_after: *not_on_or_after,
                     recipient: Some(recipient.to_owned()),
                     in_response_to: Some(request_id.to_owned()),
@@ -155,7 +155,7 @@ fn build_assertion(
                 method: Some("urn:oasis:names:tc:SAML:2.0:cm:bearer".to_string()),
                 name_id: None,
                 subject_confirmation_data: Some(SubjectConfirmationData {
-                    not_before: *not_before,
+                    not_before: None,
                     not_on_or_after: *not_on_or_after,
                     recipient: Some(recipient.to_owned()),
                     in_response_to: Some(request_id.to_owned()),


### PR DESCRIPTION
Partially reverts change from #9 by removing the `NotBefore` attribute from the `<SubjectConfirmationData>` tag of the SAML assertion, [as per the spec](https://docs.oasis-open.org/imi/identity/imi-saml2.0-profile.html#:~:text=The%20%3Csaml%3ASubjectConfirmationData%3E%20element%2C%20if%20present%2C%20MUST%20NOT%20contain%20a%20NotBefore%20or%20Recipient%20XML%20attribute).